### PR TITLE
feat: add basic mind map with gemini integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,15 @@
-# smarts
-trial of bearingsmart development
+# MindMap × LLM
+
+Simple mind map that can query Gemini Flash 2.5.
+
+## Features
+- Uses [jsMind](https://github.com/hizzgdev/jsmind) for map rendering.
+- Nodes can ask Google Gemini for answers which are added as question/answer nodes.
+- Autosaves to localStorage and can import/export JSON files.
+- Search box selects first matching node.
+- Disables AI asking while offline.
+
+## Usage
+Open `index.html` in a modern browser. Select a node and click **Ask AI** to create a question and answer pair.
+
+The app stores data in `localStorage` under the key `mindmap`.

--- a/app.js
+++ b/app.js
@@ -1,0 +1,95 @@
+const API_KEY = 'AIzaSyCu5hNmaeJnL3avQJxzorEv8n4UZoi-x4A';
+
+const jm = new jsMind({
+  container: 'jsmind_container',
+  editable: true,
+  theme: 'primary'
+});
+
+function load() {
+  const saved = localStorage.getItem('mindmap');
+  if (saved) {
+    jm.show(JSON.parse(saved));
+  } else {
+    const mind = {
+      meta: { name: 'MindMap' },
+      format: 'node_tree',
+      data: { id: 'root', topic: 'Root' }
+    };
+    jm.show(mind);
+  }
+}
+
+function save() {
+  const data = jm.get_data('node_tree');
+  localStorage.setItem('mindmap', JSON.stringify(data));
+}
+
+load();
+
+window.addEventListener('beforeunload', save);
+document.getElementById('save').onclick = save;
+
+document.getElementById('ask').onclick = async () => {
+  if (!navigator.onLine) {
+    alert('Offline: asking disabled');
+    return;
+  }
+  const selected = jm.get_selected_node();
+  if (!selected) return;
+  const prompt = selected.topic;
+  const res = await fetch(`https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash:generateContent?key=${API_KEY}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ contents: [{ parts: [{ text: prompt }]}] })
+  });
+  const data = await res.json();
+  const text = data.candidates?.[0]?.content?.parts?.[0]?.text || 'No answer';
+  const qNode = jm.add_node(selected, 'q_' + Date.now(), 'Q: ' + prompt, {type:'question'});
+  jm.add_node(qNode, 'a_' + Date.now(), 'A: ' + text, {type:'answer'});
+  save();
+};
+
+document.getElementById('search').addEventListener('input', e => {
+  const q = e.target.value.toLowerCase();
+  jm.select_clear();
+  if (!q) return;
+  const nodes = jm.mind.nodes;
+  for (const id in nodes) {
+    const n = nodes[id];
+    if (n.topic.toLowerCase().includes(q)) {
+      jm.select_node(n);
+      break;
+    }
+  }
+});
+
+document.getElementById('import').addEventListener('change', e => {
+  const file = e.target.files[0];
+  if (!file) return;
+  const reader = new FileReader();
+  reader.onload = ev => {
+    const mind = JSON.parse(ev.target.result);
+    jm.show(mind);
+    save();
+  };
+  reader.readAsText(file);
+});
+
+document.getElementById('export_json').onclick = () => {
+  const data = jm.get_data('node_tree');
+  const blob = new Blob([JSON.stringify(data)], {type: 'application/json'});
+  const a = document.createElement('a');
+  a.href = URL.createObjectURL(blob);
+  a.download = 'mind.json';
+  a.click();
+};
+
+window.addEventListener('online', () => {
+  document.getElementById('ask').disabled = false;
+});
+window.addEventListener('offline', () => {
+  document.getElementById('ask').disabled = true;
+});
+
+document.getElementById('ask').disabled = !navigator.onLine;

--- a/index.html
+++ b/index.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>MindMap × LLM</title>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/jsmind@0.4.6/style/jsmind.css" />
+  <style>
+    html,body,#jsmind_container { width:100%; height:100%; margin:0; overflow:hidden; }
+    #toolbar { position:absolute; top:0; left:0; background:#fff; padding:5px; z-index:10; }
+  </style>
+</head>
+<body>
+<div id="toolbar">
+  <input type="text" id="search" placeholder="Search..." />
+  <button id="ask">Ask AI</button>
+  <button id="save">Save</button>
+  <input type="file" id="import" />
+  <button id="export_json">Export JSON</button>
+</div>
+<div id="jsmind_container"></div>
+<script src="https://cdn.jsdelivr.net/npm/jsmind@0.4.6/jsmind.min.js"></script>
+<script type="module" src="./app.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- set up simple jsMind-based map with AI-powered question/answer nodes
- store map in localStorage and allow JSON import/export
- basic search and offline-aware Gemini requests

## Testing
- `node --check app.js`


------
https://chatgpt.com/codex/tasks/task_e_689755232d648326bd15bdf61af351e6