### PR TITLE
feat: add mind map LLM prototype

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+GEMINI_API_KEY=

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+dist
+.env

--- a/README.md
+++ b/README.md
@@ -1,2 +1,43 @@
-# smarts
-trial of bearingsmart development
+# MindMap × LLM
+
+Simple prototype combining a mind‑map editor with Gemini Flash 2.5.
+
+## Features
+
+- Interactive mind map built with [React Flow](https://reactflow.dev/)
+- Node types: **topic**, **question**, **answer**, **note**
+- Double‑click a node to ask Gemini; question and answer nodes are added
+- Auto‑saved to `localStorage`
+- Search box highlights nodes by content
+- Offline mode disables AI requests and shows a banner
+
+## Development
+
+```bash
+npm install # install dependencies
+npm run dev # requires GEMINI_API_KEY in your environment
+# or `vercel dev` to run with serverless functions
+```
+
+No tests are provided; `npm test` prints a placeholder message.
+
+### Environment Variables
+
+Create a `.env` file (or set variables in your shell) containing:
+
+```
+GEMINI_API_KEY=your_key_here
+```
+
+The front‑end calls a `/api/gemini` serverless function, which reads this
+variable server‑side so the key is never exposed to the browser.
+
+### Vercel Preview Deployment
+
+To enable preview URLs for every pull request:
+
+1. Add `GEMINI_API_KEY` as a **GitHub Actions secret** and as a Vercel
+   project environment variable (Preview and Production).
+2. Connect the GitHub repository to Vercel; each PR will build a preview
+   deploying the app.
+3. Optionally, require the Vercel check to pass before merging to `main`.

--- a/api/gemini.js
+++ b/api/gemini.js
@@ -1,0 +1,30 @@
+export default async function handler(req, res) {
+  if (req.method !== 'POST') {
+    res.status(405).json({ error: 'Method not allowed' })
+    return
+  }
+  const { prompt, maxOutputTokens = 256 } =
+    typeof req.body === 'string' ? JSON.parse(req.body) : req.body || {}
+  const body = {
+    contents: [{ parts: [{ text: prompt }] }],
+    generationConfig: { maxOutputTokens }
+  }
+  try {
+    const response = await fetch(
+      `https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent?key=${process.env.GEMINI_API_KEY}`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body)
+      }
+    )
+    const data = await response.json()
+    const text =
+      data?.candidates?.[0]?.content?.parts?.map((p) => p.text).join('') ||
+      'No response'
+    res.status(200).json({ text })
+  } catch (err) {
+    console.error('Gemini error', err)
+    res.status(500).json({ error: 'Gemini request failed' })
+  }
+}

--- a/index.html
+++ b/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>MindMap × LLM</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "smarts",
+  "version": "1.0.0",
+  "description": "MindMap × LLM demo application",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "test": "echo 'no tests'"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "reactflow": "^11.10.2"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.2.0",
+    "vite": "^5.0.0"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC"
+}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,0 +1,29 @@
+import React, { useState, useEffect } from 'react'
+import MindMap from './components/MindMap.jsx'
+
+export default function App() {
+  const [query, setQuery] = useState('')
+  const [online, setOnline] = useState(navigator.onLine)
+
+  useEffect(() => {
+    const update = () => setOnline(navigator.onLine)
+    window.addEventListener('online', update)
+    window.addEventListener('offline', update)
+    return () => {
+      window.removeEventListener('online', update)
+      window.removeEventListener('offline', update)
+    }
+  }, [])
+
+  return (
+    <div>
+      {!online && <div className="offline-banner">⚠ Offline: AI disabled</div>}
+      <input
+        value={query}
+        onChange={e => setQuery(e.target.value)}
+        placeholder="Search"
+      />
+      <MindMap search={query} online={online} />
+    </div>
+  )
+}

--- a/src/components/MindMap.jsx
+++ b/src/components/MindMap.jsx
@@ -1,0 +1,100 @@
+import React, { useState, useCallback, useEffect } from 'react'
+import ReactFlow, { addEdge, Background, Controls, MiniMap, useReactFlow } from 'reactflow'
+import 'reactflow/dist/style.css'
+import { askGemini } from '../services/gemini.js'
+
+const defaultNode = {
+  id: 'root',
+  type: 'topic',
+  data: { label: 'Root' },
+  position: { x: 0, y: 0 }
+}
+
+const load = () => {
+  try {
+    const stored = JSON.parse(localStorage.getItem('mindmap') || '{"nodes":[],"edges":[]}')
+    if (!stored.nodes.length) stored.nodes = [defaultNode]
+    return stored
+  } catch {
+    return { nodes: [defaultNode], edges: [] }
+  }
+}
+
+export default function MindMap({ search, online }) {
+  const store = load()
+  const [nodes, setNodes] = useState(store.nodes)
+  const [edges, setEdges] = useState(store.edges)
+  const instance = useReactFlow()
+
+  useEffect(() => {
+    localStorage.setItem('mindmap', JSON.stringify({ nodes, edges }))
+  }, [nodes, edges])
+
+  const onConnect = useCallback(
+    (params) => setEdges((eds) => addEdge(params, eds)),
+    []
+  )
+
+  const addQuestion = async (node) => {
+    if (!online) return
+    const questionId = `q_${Date.now()}`
+    const answerId = `a_${Date.now()}`
+    setNodes((nds) => nds.concat(
+      { id: questionId, type: 'question', data: { label: '...' }, position: { x: node.position.x + 200, y: node.position.y } },
+      { id: answerId, type: 'answer', data: { label: '...' }, position: { x: node.position.x + 400, y: node.position.y } }
+    ))
+    setEdges((eds) => eds.concat(
+      { id: `e${node.id}-${questionId}`, source: node.id, target: questionId },
+      { id: `e${questionId}-${answerId}`, source: questionId, target: answerId }
+    ))
+    const reply = await askGemini(node.data.label)
+    setNodes((nds) => nds.map((n) => (n.id === answerId ? { ...n, data: { label: reply } } : n)))
+  }
+
+  const highlight = search.trim().toLowerCase()
+  const styleFor = (n) =>
+    highlight && n.data.label.toLowerCase().includes(highlight)
+      ? { border: '2px solid orange' }
+      : {}
+
+  useEffect(() => {
+    if (!highlight) return
+    const match = nodes.find((n) => n.data.label.toLowerCase().includes(highlight))
+    if (match) instance.fitView({ nodes: [match], duration: 400 })
+  }, [highlight, nodes, instance])
+
+  const nodeTypes = {
+    topic: (props) => (
+      <div style={{ padding: 10, ...styleFor(props) }} onDoubleClick={() => addQuestion(props)}>
+        {props.data.label}
+      </div>
+    ),
+    question: (props) => (
+      <div style={{ padding: 10, background: '#eef', ...styleFor(props) }}>{props.data.label}</div>
+    ),
+    answer: (props) => (
+      <div style={{ padding: 10, background: '#efe', ...styleFor(props) }}>{props.data.label}</div>
+    ),
+    note: (props) => (
+      <div style={{ padding: 10, background: '#ffd', ...styleFor(props) }}>{props.data.label}</div>
+    ),
+  }
+
+  return (
+    <div style={{ width: '100%', height: '90vh' }}>
+      <ReactFlow
+        nodes={nodes}
+        edges={edges}
+        onNodesChange={setNodes}
+        onEdgesChange={setEdges}
+        onConnect={onConnect}
+        nodeTypes={nodeTypes}
+        fitView
+      >
+        <MiniMap />
+        <Controls />
+        <Background />
+      </ReactFlow>
+    </div>
+  )
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,0 +1,9 @@
+import React from 'react'
+import ReactDOM from 'react-dom/client'
+import App from './App.jsx'
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+)

--- a/src/services/gemini.js
+++ b/src/services/gemini.js
@@ -1,0 +1,14 @@
+export async function askGemini(prompt) {
+  try {
+    const res = await fetch('/api/gemini', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ prompt })
+    })
+    const data = await res.json()
+    return data.text || 'No response'
+  } catch (err) {
+    console.error('Gemini error', err)
+    return 'Error'
+  }
+}

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+
+export default defineConfig({
+  plugins: [react()],
+})


### PR DESCRIPTION
## Summary
- proxy Gemini API through serverless function using process.env.GEMINI_API_KEY
- remove hard-coded key and load env config via .env example
- document Vercel preview deployment and env setup

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689755232d648326bd15bdf61af351e6